### PR TITLE
Fix a bug when launching the chat in `Docker`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["uvicorn", "logic.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]


### PR DESCRIPTION
### Description:
An error occurs when launching the chat in `Docker` due to an imncorrect main file path specified iin the `Dockerfile`.
<img width="568" height="65" alt="image" src="https://github.com/user-attachments/assets/4b9b9704-16db-4161-af71-e76a557f8147" />
