### PR TITLE
Fix a bug caused by an incorrect directory name when running in `Docker`

### DIFF
--- a/logic/main.py
+++ b/logic/main.py
@@ -4,14 +4,17 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from view import get_gemini_answer
+from logic.view import get_gemini_answer
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+STATIC_DIR = ROOT_DIR / "static"
 
 app = FastAPI()
-
 app.mount(
     "/static",
     StaticFiles(
-        directory="../static",
+        directory=STATIC_DIR,
         html=True
     ),
     name="static"
@@ -27,7 +30,7 @@ app.add_middleware(
 
 @app.get("/")
 async def serve_home():
-    return FileResponse("../static/chat.html")
+    return FileResponse(STATIC_DIR / "chat.html")
 
 
 @app.post("/chat")


### PR DESCRIPTION
### Description:
An error occurs when running in `Docker`:
<img width="337" height="49" alt="image" src="https://github.com/user-attachments/assets/320b1e42-cdec-481d-85a1-5c2c660b4332" />
There was also a misconfigured directory name that causes another error.